### PR TITLE
修改isIPhoneX的判断条件

### DIFF
--- a/tabbarDemo/tabbarComponent/tabbar.js
+++ b/tabbarDemo/tabbarComponent/tabbar.js
@@ -39,7 +39,7 @@ Component({
    * 组件的初始数据
    */
   data: {
-    isIphoneX: app.globalData.systemInfo.model == "iPhone X" ? true : false,
+    isIphoneX: app.globalData.systemInfo.model.search('iPhone X') != -1 ? true : false
   },
 
   /**


### PR DESCRIPTION
iPhone X在真机模式下的model值为"iPhone X (GSM+CDMA)<iPhone10,3>"，所以isIPhoneX的判断在模拟器下可用，真机下不生效，修改之~